### PR TITLE
type 6 is double not uint

### DIFF
--- a/resources/gdb-imagewatch.py
+++ b/resources/gdb-imagewatch.py
@@ -134,9 +134,10 @@ def get_buffer_size(width, height, channels, type, step):
        type == gdbiwtype.GIW_TYPES_INT16:
         channel_size = 2 # 2 bytes per element
     elif type == gdbiwtype.GIW_TYPES_INT32 or \
-         type == gdbiwtype.GIW_TYPES_UINT32 or \
          type == gdbiwtype.GIW_TYPES_FLOAT32:
         channel_size = 4 # 4 bytes per element
+    elif type == gdbiwtype.GIW_TYPES_FLOAT64:
+        channel_size = 8 # 8 bytes per element
         pass
 
     return channel_size * channels * step*height

--- a/resources/gdbiwtype.py
+++ b/resources/gdbiwtype.py
@@ -3,7 +3,7 @@ GIW_TYPES_UINT16 = 2
 GIW_TYPES_INT16 = 3
 GIW_TYPES_INT32 = 4
 GIW_TYPES_FLOAT32 = 5
-GIW_TYPES_UINT32 = 6
+GIW_TYPES_FLOAT64 = 6
 
 ##
 # Default values created for OpenCV Mat structures. Change it according to your
@@ -39,9 +39,10 @@ def get_buffer_info(picked_obj):
        type == GIW_TYPES_INT16:
         step = int(step / 2)
     elif type == GIW_TYPES_INT32 or \
-         type == GIW_TYPES_UINT32 or \
          type == GIW_TYPES_FLOAT32:
         step = int(step / 4)
+    elif type == GIW_TYPES_FLOAT64:
+        step = int(step / 8)
 
     return (buffer, width, height, channels, type, step)
 

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -49,8 +49,8 @@ void Buffer::getPixelInfo(stringstream& message, int x, int y) {
             int fpix = reinterpret_cast<int*>(buffer)[pos+c];
             message << fpix;
         }
-        else if(type == Buffer::BufferType::UnsignedInt32) {
-            unsigned int fpix = reinterpret_cast<unsigned int*>(buffer)[pos+c];
+        else if(type == Buffer::BufferType::Float64) {
+            double fpix = reinterpret_cast<double*>(buffer)[pos+c];
             message << fpix;
         }
         if (c<channels-1) {
@@ -87,9 +87,9 @@ void Buffer::recomputeMinColorValues() {
                 else if(type == BufferType::Int32)
                     lowest[c] = std::min(lowest[c],
                                          static_cast<float>(reinterpret_cast<int*>(buffer)[channels*i + c]));
-                else if(type == BufferType::UnsignedInt32)
+                else if(type == BufferType::Float64)
                     lowest[c] = std::min(lowest[c],
-                                         static_cast<float>(reinterpret_cast<unsigned int*>(buffer)[channels*i + c]));
+                                         static_cast<float>(reinterpret_cast<double*>(buffer)[channels*i + c]));
             }
         }
     }
@@ -126,9 +126,9 @@ void Buffer::recomputeMaxColorValues() {
                 else if(type == BufferType::Int32)
                     upper[c] = std::max(upper[c],
                                         static_cast<float>(reinterpret_cast<int*>(buffer)[channels*i + c]));
-                else if(type == BufferType::UnsignedInt32)
+                else if(type == BufferType::Float64)
                     upper[c] = std::max(upper[c],
-                                        static_cast<float>(reinterpret_cast<unsigned int*>(buffer)[channels*i + c]));
+                                        static_cast<float>(reinterpret_cast<double*>(buffer)[channels*i + c]));
             }
         }
     }
@@ -162,8 +162,9 @@ void Buffer::computeContrastBrightnessParameters() {
             maxIntensity = std::numeric_limits<unsigned short>::max();
         else if(type == BufferType::Int32)
             maxIntensity = std::numeric_limits<int>::max();
-        else if(type == BufferType::UnsignedInt32)
+        else if(type == BufferType::Float64)
             maxIntensity = std::numeric_limits<unsigned int>::max();
+//            maxIntensity = std::numeric_limits<double>::max();
         else if(type == BufferType::Float32)
             maxIntensity = 1.0f;
 
@@ -369,8 +370,9 @@ void Buffer::setup_gl_buffer() {
         tex_type = GL_UNSIGNED_SHORT;
     } else if (type == BufferType::Int32) {
         tex_type = GL_INT;
-    } else if (type == BufferType::UnsignedInt32) {
-        tex_type = GL_UNSIGNED_INT;
+    } else if (type == BufferType::Float64) {
+//        tex_type = GL_UNSIGNED_INT;
+        tex_type = GL_DOUBLE;
     }
 
     if(channels == 1) {

--- a/src/buffer.hpp
+++ b/src/buffer.hpp
@@ -13,7 +13,7 @@ public:
     std::vector<GLuint> buff_tex;
     static const float no_ac_params[8];
 
-    enum class BufferType { UnsignedByte = 0, UnsignedShort = 2, Short = 3, Int32 = 4, Float32 = 5, UnsignedInt32 = 6 };
+    enum class BufferType { UnsignedByte = 0, UnsignedShort = 2, Short = 3, Int32 = 4, Float32 = 5, Float64 = 6 };
 
     ~Buffer();
 

--- a/src/buffer_exporter.cpp
+++ b/src/buffer_exporter.cpp
@@ -94,8 +94,8 @@ const char* get_type_descriptor<float>() {
 }
 
 template<>
-const char* get_type_descriptor<uint32_t>() {
-    return "uint32";
+const char* get_type_descriptor<double>() {
+    return "double";
 }
 
 template<typename T>
@@ -137,8 +137,8 @@ void BufferExporter::export_buffer(const Buffer *buffer, const std::string &path
         case Buffer::BufferType::Float32:
           export_bitmap<float>(path.c_str(), buffer, buffer->channels);
             break;
-        case Buffer::BufferType::UnsignedInt32:
-          export_bitmap<uint32_t>(path.c_str(), buffer, buffer->channels);
+        case Buffer::BufferType::Float64:
+          export_bitmap<double>(path.c_str(), buffer, buffer->channels);
             break;
         }
     } else {
@@ -159,8 +159,8 @@ void BufferExporter::export_buffer(const Buffer *buffer, const std::string &path
         case Buffer::BufferType::Float32:
           export_binary<float>(path.c_str(), buffer, buffer->channels);
             break;
-        case Buffer::BufferType::UnsignedInt32:
-          export_binary<uint32_t>(path.c_str(), buffer, buffer->channels);
+        case Buffer::BufferType::Float64:
+          export_binary<double>(path.c_str(), buffer, buffer->channels);
             break;
         }
     }

--- a/src/buffer_values.cpp
+++ b/src/buffer_values.cpp
@@ -171,9 +171,9 @@ void BufferValues::draw(const mat4& projection, const mat4& viewInv) {
                         int fpix = reinterpret_cast<int*>(buffer)[pos];
                         sprintf(pix_label, "%d", fpix);
                     }
-                    else if(type == Buffer::BufferType::UnsignedInt32) {
-                        unsigned int fpix = reinterpret_cast<unsigned int*>(buffer)[pos];
-                        sprintf(pix_label, "%d", fpix);
+                    else if(type == Buffer::BufferType::Float64) {
+                        double fpix = reinterpret_cast<double*>(buffer)[pos];
+                        sprintf(pix_label, "%.3f", fpix);
                     }
 
                     draw_text(projection, viewInv, camRot, pix_label, x + pos_center_x, y + pos_center_y, 0.0);
@@ -204,9 +204,9 @@ void BufferValues::draw(const mat4& projection, const mat4& viewInv) {
                             sprintf(pix_label, "%d", fpix);
                             draw_text(projection, viewInv, camRot, pix_label, x + pos_center_x, y + pos_center_y, y_off);
                         }
-                        else if(type == Buffer::BufferType::UnsignedInt32) {
-                            unsigned int fpix = reinterpret_cast<unsigned int*>(buffer)[pos+c];
-                            sprintf(pix_label, "%d", fpix);
+                        else if(type == Buffer::BufferType::Float64) {
+                            double fpix = reinterpret_cast<double*>(buffer)[pos+c];
+                            sprintf(pix_label, "%f", fpix);
                             draw_text(projection, viewInv, camRot, pix_label, x + pos_center_x, y + pos_center_y, y_off);
                         }
                     }
@@ -237,9 +237,9 @@ void BufferValues::draw(const mat4& projection, const mat4& viewInv) {
                             sprintf(pix_label, "%d", fpix);
                             draw_text(projection, viewInv, camRot, pix_label, x + pos_center_x, y + pos_center_y, y_off);
                         }
-                        else if(type == Buffer::BufferType::UnsignedInt32) {
-                            unsigned int fpix = reinterpret_cast<unsigned int*>(buffer)[pos+c];
-                            sprintf(pix_label, "%d", fpix);
+                        else if(type == Buffer::BufferType::Float64) {
+                            double fpix = reinterpret_cast<double*>(buffer)[pos+c];
+                            sprintf(pix_label, "%.3f", fpix);
                             draw_text(projection, viewInv, camRot, pix_label, x + pos_center_x, y + pos_center_y, y_off);
                         }
                     }
@@ -270,9 +270,9 @@ void BufferValues::draw(const mat4& projection, const mat4& viewInv) {
                             sprintf(pix_label, "%d", fpix);
                             draw_text(projection, viewInv, camRot, pix_label, x + pos_center_x, y + pos_center_y, y_off);
                         }
-                        else if(type == Buffer::BufferType::UnsignedInt32) {
-                            unsigned int fpix = reinterpret_cast<unsigned int*>(buffer)[pos+c];
-                            sprintf(pix_label, "%d", fpix);
+                        else if(type == Buffer::BufferType::Float64) {
+                            double fpix = reinterpret_cast<double*>(buffer)[pos+c];
+                            sprintf(pix_label, "%.3f", fpix);
                             draw_text(projection, viewInv, camRot, pix_label, x + pos_center_x, y + pos_center_y, y_off);
                         }
                     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -386,8 +386,8 @@ string MainWindow::get_type_label(Buffer::BufferType type, int channels)
         result << "uint16";
     } else if(type == Buffer::BufferType::Int32) {
         result << "int32";
-    } else if(type == Buffer::BufferType::UnsignedInt32) {
-        result << "uint32";
+    } else if(type == Buffer::BufferType::Float64) {
+        result << "float64";
     }
     result << "x" << channels;
 


### PR DESCRIPTION
cv::Mat of type 6 have doubles not uint32 as in the current code. With those modifications I can see the correct numbers now for a Mat with doubles. What I couldn't achieve was the right color for the doubles, everything looks black here, but maybe you can fix that easily?