### PR TITLE
Update installation script

### DIFF
--- a/configure_ubuntu_16.sh
+++ b/configure_ubuntu_16.sh
@@ -10,7 +10,6 @@ cd build
 export QT_SELECT=5
 qmake ..
 make -j$(nproc)
-sudo make install
 cd ..
 echo "source $(pwd)/build/gdb-imagewatch.py" > ~/.gdbinit
 echo "Completed configuration of GDB ImageWatch."

--- a/configure_ubuntu_16.sh
+++ b/configure_ubuntu_16.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 echo "Starting GDB ImageWatch configuration for Ubuntu 16.04."
 set -e
-sudo apt-get install python3-pip
-sudo apt-get -y install libpython3-dev libglew-dev python3-numpy python3-pip texinfo libfreetype6-dev libeigen3-dev
-sudo pip3 install pysigset
-mkdir build
+sudo apt update
+sudo apt install -y python3-pip
+sudo apt install -y libpython3-dev libglew-dev python3-numpy python3-pip texinfo libfreetype6-dev libeigen3-dev
+sudo -H pip3 install pysigset
+mkdir -p build
 cd build
 export QT_SELECT=5
 qmake ..
 make -j$(nproc)
-make install
+sudo make install
 cd ..
 echo "source $(pwd)/build/gdb-imagewatch.py" > ~/.gdbinit
 echo "Completed configuration of GDB ImageWatch."

--- a/configure_ubuntu_16.sh
+++ b/configure_ubuntu_16.sh
@@ -2,7 +2,6 @@
 echo "Starting GDB ImageWatch configuration for Ubuntu 16.04."
 set -e
 sudo apt update
-sudo apt install -y python3-pip
 sudo apt install -y libpython3-dev libglew-dev python3-numpy python3-pip texinfo libfreetype6-dev libeigen3-dev
 sudo -H pip3 install pysigset
 mkdir -p build


### PR DESCRIPTION
- Add `-y` flags to installation commands to automatically confirm.
- Use `apt` instead of `apt-get`, which does exactly the same, but is shorter
- Add `-H` to `sudo pip3` according to warning
- Add `-p` to `mkdir` in case `build` already exists
- Remove duplicate `install python3-pip`