### PR TITLE
Use glTexImage2D instead of glTexStorage2D

### DIFF
--- a/src/ui/gl_canvas.cpp
+++ b/src/ui/gl_canvas.cpp
@@ -36,7 +36,7 @@ using namespace std;
 
 GLCanvas::GLCanvas(QWidget* parent)
     : QOpenGLWidget(parent)
-    , QOpenGLExtraFunctions()
+    , QOpenGLFunctions()
     , mouse_x_(0)
     , mouse_y_(0)
     , initialized_(false)

--- a/src/ui/gl_canvas.h
+++ b/src/ui/gl_canvas.h
@@ -29,7 +29,7 @@
 #include <memory>
 
 #include <QMouseEvent>
-#include <QOpenGLExtraFunctions>
+#include <QOpenGLFunctions>
 #include <QOpenGLWidget>
 
 
@@ -38,7 +38,7 @@ class Stage;
 class GLTextRenderer;
 
 
-class GLCanvas : public QOpenGLWidget, public QOpenGLExtraFunctions
+class GLCanvas : public QOpenGLWidget, public QOpenGLFunctions
 {
     Q_OBJECT
   public:

--- a/src/ui/gl_text_renderer.cpp
+++ b/src/ui/gl_text_renderer.cpp
@@ -91,11 +91,25 @@ void GLTextRenderer::generate_glyphs_texture()
 
     const int mipmap_levels = 5;
 
-    gl_canvas_->glTexStorage2D(GL_TEXTURE_2D,
-                               mipmap_levels,
-                               GL_R8,
-                               text_texture_width,
-                               text_texture_height);
+    {
+        int tex_level_width = text_texture_width;
+        int tex_level_height = text_texture_height;
+
+        for (int i = 0; i < mipmap_levels; ++i) {
+            gl_canvas_->glTexImage2D(GL_TEXTURE_2D,
+                                     i,
+                                     GL_R8,
+                                     tex_level_width,
+                                     tex_level_height,
+                                     0,
+                                     GL_RED,
+                                     GL_UNSIGNED_BYTE,
+                                     nullptr);
+
+            tex_level_width = std::max(1, tex_level_width / 2);
+            tex_level_height = std::max(1, tex_level_height / 2);
+        }
+    }
 
     QPixmap pixmap(texture_size);
     pixmap.fill(QColor(0, 0, 0));
@@ -168,15 +182,15 @@ void GLTextRenderer::generate_glyphs_texture()
 
     // Clears generated buffer
     {
-        glTexSubImage2D(GL_TEXTURE_2D,
-                        0,
-                        0,
-                        0,
-                        text_texture_width,
-                        text_texture_height,
-                        GL_RED,
-                        GL_UNSIGNED_BYTE,
-                        packed_texture.data());
+        gl_canvas_->glTexSubImage2D(GL_TEXTURE_2D,
+                                    0,
+                                    0,
+                                    0,
+                                    text_texture_width,
+                                    text_texture_height,
+                                    GL_RED,
+                                    GL_UNSIGNED_BYTE,
+                                    packed_texture.data());
     }
 
     int x = 0;

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -571,8 +571,16 @@ void Buffer::setup_gl_buffer()
                                       ty * max_texture_size);
             gl_canvas_->glPixelStorei(GL_UNPACK_SKIP_PIXELS,
                                       tx * max_texture_size);
-            gl_canvas_->glTexStorage2D(
-                GL_TEXTURE_2D, 1, GL_RGBA32F, buff_w, buff_h);
+
+            gl_canvas_->glTexImage2D(GL_TEXTURE_2D,
+                                     0,
+                                     GL_RGBA32F,
+                                     buff_w,
+                                     buff_h,
+                                     0,
+                                     tex_format,
+                                     tex_type,
+                                     nullptr);
 
             gl_canvas_->glTexSubImage2D(GL_TEXTURE_2D,
                                         0,


### PR DESCRIPTION
This should effectively reduce OpenGL requirements, since glTexImage2D is part
of Gl since version 2.0, while glTexStorage2D was introduced in 4.2.