### PR TITLE
Fix opencv giwtype (quick and dirty)

### DIFF
--- a/resources/giwscripts/giwtypes/opencv.py
+++ b/resources/giwscripts/giwtypes/opencv.py
@@ -62,7 +62,8 @@ class Mat(interface.TypeInspectorInterface):
             'channels': channels,
             'type': type_value,
             'row_stride': row_stride,
-            'pixel_layout': pixel_layout
+            'pixel_layout': pixel_layout,
+            'transpose_buffer' : False
         }
 
     def is_symbol_observable(self, symbol):


### PR DESCRIPTION
gdb-imagewatch currently checks for a field name "tranpose_buffer" in
a hard-coded manner.

This commit is a dirty fix that always asign 'False' to the that field.